### PR TITLE
ref: Parses port and sets explicit host

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,8 @@
 import 'dotenv/config';
 import App from './App.ts';
 
-const PORT = process.env.PORT || 3000;
+const PORT = parseInt(process.env.PORT || '3000', 10);
 
-App.listen(PORT, () => {
+App.listen(PORT, '0.0.0.0', () => {
     console.log(`Server is running on Port ${PORT}`);
 });


### PR DESCRIPTION
Converts environment variable to an integer value for reliable port handling.
Sets host binding to '0.0.0.0' to support external access.